### PR TITLE
ハンドヘルドのBluetoothSPPでのサーバーとの送受信の移植および、wearへの転送

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -21,5 +21,6 @@
             </intent-filter>
         </activity>
     </application>
-
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 </manifest>

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
@@ -38,8 +38,12 @@ public class BluetoothClient {
     private boolean is_inited=false;
     private boolean is_connected=false;
 
+
+    private GlobalVariables globalv;
+
     public BluetoothClient(MainActivity activity) {
         this.activity = activity;
+        globalv=(GlobalVariables) activity.getApplication();
     }
 
     /**
@@ -216,10 +220,7 @@ public class BluetoothClient {
                 btOut.write(buffer_);
                 btOut.flush();
 
-                byte[] buff = new byte[512];
-                int len = btIn.read(buff); // TODO:ループして読み込み
-
-                return new String(buff, 0, len);
+                return null;
             } catch (Throwable t) {
                 doClose();
                 return t;
@@ -231,9 +232,6 @@ public class BluetoothClient {
             if (result instanceof Exception) {
                 Log.e(TAG,result.toString(),(Throwable)result);
                 activity.errorDialog(result.toString());
-            } else {
-                // 結果を画面に反映。
-                //activity.doSetResultText(result.toString());
             }
         }
     }
@@ -260,9 +258,15 @@ public class BluetoothClient {
             } else {
                 // 結果を画面に反映。
                 //activity.doSetResultText(result.toString());
+                String[] detection_code = result.toString().split(":", 0);
+                if(detection_code[0].equals("scene")){
+                    activity.SyncData(detection_code[1], "scene_name");
+                }else if(detection_code[0].equals("ready")){
+                    activity.SyncData(detection_code[1],detection_code[0]);
+                }else if(detection_code[0].equals("vibrator")){
+                    activity.SyncData(detection_code[1],detection_code[0]);
+                }
 
-                // TODO:Wearに転送する処理
-                Toast.makeText(activity, result.toString(), Toast.LENGTH_SHORT).show();//とりあえずトーストで表示
             }
         }
     }

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
@@ -1,0 +1,269 @@
+package jagsc.org.abc2016springclient;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.widget.Toast;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Created by HayatoKimura on 2016/02/17.
+ */
+public class BluetoothClient {
+
+    private static final String TAG = "BluetoothTask";
+
+    /**
+     * UUIDはサーバと一致している必要がある。
+     * - 独自サービスのUUIDはツールで生成する。（ほぼ乱数）
+     * - 注：このまま使わないように。
+     */
+    //private static final UUID APP_UUID = UUID.fromString("11111111-1111-1111-1111-111111111123");//UUID.fromString("11111111-1111-1111-1111-111111111123");
+    private static final UUID APP_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
+
+    private MainActivity activity;
+    private BluetoothAdapter bluetoothAdapter;
+    private BluetoothDevice bluetoothDevice = null;
+    private BluetoothSocket bluetoothSocket;
+    private InputStream btIn;
+    private OutputStream btOut;
+
+    private boolean is_inited=false;
+    private boolean is_connected=false;
+
+    public BluetoothClient(MainActivity activity) {
+        this.activity = activity;
+    }
+
+    /**
+     * Bluetoothの初期化。
+     */
+    public void init() {
+        // BTアダプタ取得。取れなければBT未実装デバイス。
+        bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (bluetoothAdapter == null) {
+            activity.errorDialog("This device is not implement Bluetooth.");
+            return;
+        }
+        // BTが設定で有効になっているかチェック。
+        if (!bluetoothAdapter.isEnabled()) {
+            // TODO: ユーザに許可を求める処理。
+            activity.errorDialog("This device is disabled Bluetooth.");
+            return;
+        }
+        is_inited=true;
+    }
+
+    public boolean is_inited(){
+        return is_inited;
+    }
+
+    public boolean is_connected(){
+        return is_connected;
+    }
+
+    /**
+     * @return ペアリング済みのデバイス一覧を返す。デバイス選択ダイアログ用。
+     */
+    public Set<BluetoothDevice> getPairedDevices() {
+        return bluetoothAdapter.getBondedDevices();
+    }
+
+    /**
+     * 非同期で指定されたデバイスの接続を開始する。
+     * - 選択ダイアログから選択されたデバイスを設定される。
+     * @param device 選択デバイス
+     *               nullがきたら再接続なのでbluetoothDeviceの値は更新しない
+     */
+    public void doConnect(BluetoothDevice device) {
+        if(device!=null){
+            bluetoothDevice = device;
+        }
+        try {
+            bluetoothSocket = bluetoothDevice.createRfcommSocketToServiceRecord(APP_UUID);
+            //Method m = bluetoothDevice.getClass().getMethod("createInsecureRfcommSocket", new Class[] {int.class});
+            //bluetoothSocket = (BluetoothSocket) m.invoke(bluetoothDevice, 1);
+            new ConnectTask().execute();
+        }
+        catch (IOException e) {
+            Log.e(TAG, e.toString(), e);
+            activity.errorDialog(e.toString());
+        }
+        is_connected=true;
+    }
+
+    /**
+     * 非同期でBluetoothの接続を閉じる。
+     */
+    public void doClose() {
+        new CloseTask().execute();
+        is_connected=false;
+    }
+
+    /**
+     * 非同期でメッセージの送受信を行う。
+     * @param msg 送信メッセージ.
+     */
+    public void doSend(String msg) {
+        new SendTask().execute(msg);
+    }
+
+    public void doReceive(){
+        new ReceiveTask().execute();
+    }
+
+    /**
+     * Bluetoothと接続を開始する非同期タスク。
+     * - 時間がかかる場合があるのでProcessDialogを表示する。
+     * - 双方向のストリームを開くところまで。
+     */
+    private class ConnectTask extends AsyncTask<Void, Void, Object> {
+        @Override
+        protected void onPreExecute() {
+            activity.showWaitDialog("Connect Bluetooth Device.");
+        }
+
+        @Override
+        protected Object doInBackground(Void... params) {
+            try {
+                bluetoothSocket.connect();
+                btIn = bluetoothSocket.getInputStream();
+                btOut = bluetoothSocket.getOutputStream();
+            } catch (Throwable t) {
+                doClose();
+                return t;
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Object result) {
+            if (result instanceof Throwable) {
+                Log.e(TAG,result.toString(),(Throwable)result);
+                activity.errorDialog(result.toString());
+            } else {
+                activity.hideWaitDialog();
+            }
+        }
+    }
+
+    /**
+     * Bluetoothと接続を終了する非同期タスク。
+     * - 不要かも知れないが念のため非同期にしている。
+     */
+    private class CloseTask extends AsyncTask<Void, Void, Object> {
+        @Override
+        protected Object doInBackground(Void... params) {
+            try {
+                try{btOut.close();}catch(Throwable t){/*ignore*/}
+                try{btIn.close();}catch(Throwable t){/*ignore*/}
+                bluetoothSocket.close();
+            } catch (Throwable t) {
+                return t;
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Object result) {
+            if (result instanceof Throwable) {
+                Log.e(TAG,result.toString(),(Throwable)result);
+                activity.errorDialog(result.toString());
+            }
+        }
+    }
+
+    /**
+     * サーバとメッセージの送受信を行う非同期タスク。
+     */
+    private class SendTask extends AsyncTask<String, Void, Object> {
+        @Override
+        protected Object doInBackground(String... params) {
+            try {
+                byte[] buffer_ = new byte[params[0].length()/2+1];
+                for( int i = 0; i < params[0].length(); ++i ){
+                    int tmp;
+                    switch( params[0].charAt(i) ){
+                        case '0': tmp = 0x01; break;
+                        case '1': tmp = 0x02; break;
+                        case '2': tmp = 0x03; break;
+                        case '3': tmp = 0x04; break;
+                        case '4': tmp = 0x05; break;
+                        case '5': tmp = 0x06; break;
+                        case '6': tmp = 0x07; break;
+                        case '7': tmp = 0x08; break;
+                        case '8': tmp = 0x09; break;
+                        case '9': tmp = 0x0a; break;
+                        case '-': tmp = 0x0b; break;
+                        case '.': tmp = 0x0c; break;
+                        case ',': tmp = 0x0d; break;
+                        default: tmp = 0x00; break;
+                    }
+                    if( i % 2 == 0 ){
+                        buffer_[i/2] = (byte)( tmp << 4 );
+                    }
+                    else{
+                        buffer_[i/2] += (byte)tmp;
+                    }
+                }
+                btOut.write(buffer_);
+                btOut.flush();
+
+                byte[] buff = new byte[512];
+                int len = btIn.read(buff); // TODO:ループして読み込み
+
+                return new String(buff, 0, len);
+            } catch (Throwable t) {
+                doClose();
+                return t;
+            }
+        }
+
+        @Override
+        protected void onPostExecute(Object result) {
+            if (result instanceof Exception) {
+                Log.e(TAG,result.toString(),(Throwable)result);
+                activity.errorDialog(result.toString());
+            } else {
+                // 結果を画面に反映。
+                //activity.doSetResultText(result.toString());
+            }
+        }
+    }
+
+    private class ReceiveTask extends AsyncTask<String, Void, Object> {
+        @Override
+        protected Object doInBackground(String... params) {
+            try {
+                byte[] buff = new byte[512];
+                int len = btIn.read(buff);
+
+                return new String(buff, 0, len);
+            } catch (Throwable t) {
+                doClose();
+                return t;
+            }
+        }
+
+        @Override
+        protected void onPostExecute(Object result) {
+            if (result instanceof Exception) {
+                Log.e(TAG, result.toString(), (Throwable) result);
+                activity.errorDialog(result.toString());
+            } else {
+                // 結果を画面に反映。
+                //activity.doSetResultText(result.toString());
+
+                // TODO:Wearに転送する処理
+                Toast.makeText(activity, result.toString(), Toast.LENGTH_SHORT).show();//とりあえずトーストで表示
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/GlobalVariables.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/GlobalVariables.java
@@ -1,0 +1,10 @@
+package jagsc.org.abc2016springclient;
+
+import android.app.Application;
+
+/**
+ * Created by HayatoKimura on 2016/02/21.
+ */
+public class GlobalVariables extends Application {
+    final static String DATA_PATH = "/datapath";
+}

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
@@ -18,12 +18,16 @@ import android.widget.TextView;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.PendingResult;
+import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.DataMap;
 import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.MessageEvent;
+import com.google.android.gms.wearable.PutDataMapRequest;
+import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
 import java.util.Set;
@@ -43,6 +47,10 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
     private String resultstr;
 
     private boolean connected_;
+
+
+    private GlobalVariables globalv;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -51,6 +59,8 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
         setSupportActionBar(toolbar);
 
 
+
+        globalv=(GlobalVariables) this.getApplication();
         mGoogleApiClient = new GoogleApiClient.Builder(this).addConnectionCallbacks(this).addApi(Wearable.API).build();
         resultstr="";
 
@@ -240,6 +250,32 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
                 });
             }
         }
+    }
+
+
+    /*データの種類
+    key	     type    備考        format(BluetoothSPP)
+    --------------------------------------------------
+    scene    string  シーン情報   "scene:ex"
+    ready    boolean 準備完了状態 "ready:ex"
+    vibrator integer バイブ時間   "vibrator:ex(ms)"
+    */
+    public void SyncData(String key_name,String sync_data){//HandheldとWear間の各種データの更新をする。データの種類は上記のコメントを参照
+        PutDataMapRequest dataMapRequest = PutDataMapRequest.create(globalv.DATA_PATH);
+        DataMap dataMap = dataMapRequest.getDataMap();
+        //Data set
+        dataMap.putString(key_name, sync_data);//("keyname",data);
+
+        // Data Push
+        PutDataRequest request = dataMapRequest.asPutDataRequest();
+        PendingResult<DataApi.DataItemResult> pendingResult = Wearable.DataApi.putDataItem(mGoogleApiClient, request);
+        pendingResult.setResultCallback(new ResultCallback<DataApi.DataItemResult>() {
+            @Override
+            public void onResult(DataApi.DataItemResult dataItemResult) {
+                Log.d("TAG", "onResult:" + dataItemResult.getStatus().toString());
+            }
+        });
+
     }
 
     @Override

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
@@ -1,22 +1,58 @@
 package jagsc.org.abc2016springclient;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.ProgressDialog;
+import android.bluetooth.BluetoothDevice;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.View;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.TextView;
 
-public class MainActivity extends AppCompatActivity {
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.wearable.DataApi;
+import com.google.android.gms.wearable.DataEvent;
+import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataMap;
+import com.google.android.gms.wearable.MessageApi;
+import com.google.android.gms.wearable.MessageEvent;
+import com.google.android.gms.wearable.Wearable;
 
+import java.util.Set;
+
+public class MainActivity extends AppCompatActivity implements GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener,MessageApi.MessageListener,DataApi.DataListener  {
+
+    private final static int DEVICES_DIALOG = 1;
+    private final static int ERROR_DIALOG = 2;
+
+    private BluetoothClient bluetoothClient = new BluetoothClient(this);
+
+    private ProgressDialog waitDialog;
+    private String errorMessage = "";
+
+    private GoogleApiClient mGoogleApiClient;
+    private TextView resultview;
+    private String resultstr;
+
+    private boolean connected_;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+
+
+        mGoogleApiClient = new GoogleApiClient.Builder(this).addConnectionCallbacks(this).addApi(Wearable.API).build();
+        resultstr="";
 
        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
@@ -26,6 +62,184 @@ public class MainActivity extends AppCompatActivity {
                         .setAction("Action", null).show();
             }
         });
+    }
+
+    @Override
+    protected void onStop() {
+        // TODO Auto-generated method stub
+        super.onStop();
+        if(bluetoothClient != null && bluetoothClient.is_connected()){
+            bluetoothClient.doClose();
+        }
+        connected_ = false;
+
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        mGoogleApiClient.connect();
+        if(bluetoothClient.is_inited()){
+            bluetoothClient.doConnect(null);
+        }else{
+            // Bluetooth初期化
+            bluetoothClient.init();
+            // ペアリング済みデバイスの一覧を表示してユーザに選ばせる。
+            showDialog(DEVICES_DIALOG);
+        }
+
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if(bluetoothClient != null && bluetoothClient.is_connected()){
+            bluetoothClient.doClose();
+        }
+    }
+
+    //----------------------------------------------------------------
+    // 以下、ダイアログ関連
+    @Override
+    protected Dialog onCreateDialog(int id) {
+        if (id == DEVICES_DIALOG) return createDevicesDialog();
+        if (id == ERROR_DIALOG) return createErrorDialog();
+        return null;
+    }
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void onPrepareDialog(int id, Dialog dialog) {
+        if (id == ERROR_DIALOG) {
+            ((AlertDialog) dialog).setMessage(errorMessage);
+        }
+        super.onPrepareDialog(id, dialog);
+    }
+
+    public Dialog createDevicesDialog() {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        alertDialogBuilder.setTitle("Select device");
+
+        // ペアリング済みデバイスをダイアログのリストに設定する。
+        Set<BluetoothDevice> pairedDevices = bluetoothClient.getPairedDevices();
+        final BluetoothDevice[] devices = pairedDevices.toArray(new BluetoothDevice[0]);
+        String[] items = new String[devices.length];
+        for (int i=0;i<devices.length;i++) {
+            items[i] = devices[i].getName();
+        }
+
+        alertDialogBuilder.setItems(items, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+                // 選択されたデバイスを通知する。そのまま接続開始。
+                bluetoothClient.doConnect(devices[which]);
+            }
+        });
+        alertDialogBuilder.setCancelable(false);
+        return alertDialogBuilder.create();
+    }
+
+    @SuppressWarnings("deprecation")
+    public void errorDialog(String msg) {
+        if (this.isFinishing()) return;
+        this.errorMessage = msg;
+        this.showDialog(ERROR_DIALOG);
+    }
+    public Dialog createErrorDialog() {
+        AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
+        alertDialogBuilder.setTitle("Error");
+        alertDialogBuilder.setMessage("");
+        alertDialogBuilder.setPositiveButton("Exit", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+                finish();
+            }
+        });
+        return alertDialogBuilder.create();
+    }
+
+    public void showWaitDialog(String msg) {
+        if (waitDialog == null) {
+            waitDialog = new ProgressDialog(this);
+        }
+        waitDialog.setMessage(msg);
+        waitDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        waitDialog.show();
+    }
+    public void hideWaitDialog() {
+        waitDialog.dismiss();
+        connected_ = true;
+        resultview.setText("connected");
+    }
+
+    @Override
+    protected void onPause(){
+        super.onPause();
+        if(mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            //mGoogleApiClient.disconnect();
+            Wearable.MessageApi.removeListener(mGoogleApiClient, this);
+            mGoogleApiClient.disconnect();
+        }
+        if(bluetoothClient != null && bluetoothClient.is_connected()){
+            bluetoothClient.doClose();
+            connected_=false;
+        }
+    }
+
+    @Override
+    public void onConnected(Bundle bundle){
+        Log.d("TAG", "onConnected");
+        Wearable.DataApi.addListener(mGoogleApiClient, this);
+        Wearable.MessageApi.addListener(mGoogleApiClient, this);
+
+    }
+    @Override
+    public void onConnectionSuspended(int i){
+        Log.d("TAG", "onConnectionSuspended");
+    }
+    @Override
+    public void onConnectionFailed(ConnectionResult connectionResult){
+        Log.e("TAG", "onConnectionFailed");
+    }
+
+    @Override
+    public void onMessageReceived(MessageEvent messageEvent) {
+        if (messageEvent.getPath().equals("/sensordata")) {
+            resultstr = new String(messageEvent.getData());
+            if(connected_){
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        resultview.setText(resultstr);
+                        SendSensorNum(resultstr);
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public void onDataChanged(DataEventBuffer dataEvents) {
+        for (DataEvent event : dataEvents) {
+            if (event.getType() == DataEvent.TYPE_DELETED) {
+                Log.d("TAG", "DataItem deleted: " + event.getDataItem().getUri());
+            } else if (event.getType() == DataEvent.TYPE_CHANGED) {
+                Log.d("TAG", "DataItem changed: " + event.getDataItem().getUri());
+                DataMap dataMap = DataMap.fromByteArray(event.getDataItem().getData());
+                //variable = dataMap.get~("keyname"); で受け取る
+
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        //受け取り後の処理をここに
+                        //resultview.setText(resultstr);
+                    }
+                });
+            }
+        }
     }
 
     @Override
@@ -49,4 +263,11 @@ public class MainActivity extends AppCompatActivity {
 
         return super.onOptionsItemSelected(item);
     }
+
+    public void SendSensorNum(String sendstr){
+        bluetoothClient.doSend(sendstr);
+        bluetoothClient.doReceive();
+
+    }
+
 }

--- a/wear/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
+++ b/wear/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
@@ -12,17 +12,19 @@ import android.widget.TextView;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.PendingResult;
+import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.wearable.DataApi;
+import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataMap;
 import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.MessageEvent;
 import com.google.android.gms.wearable.Wearable;
 
-import java.io.Serializable;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 
 public class MainActivity extends WearableActivity implements View.OnClickListener,GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener,DataApi.DataListener,MessageApi.MessageListener{
@@ -127,6 +129,7 @@ public class MainActivity extends WearableActivity implements View.OnClickListen
 
     @Override
     public void onConnected(Bundle bundle) {
+        Wearable.DataApi.addListener(globalv.mGoogleApiClient, this);
         Log.d("TAG", "onConnected");
     }
 
@@ -137,12 +140,51 @@ public class MainActivity extends WearableActivity implements View.OnClickListen
 
 
 
-    public void onDataChanged(DataEventBuffer dataEventBuffer) {//dataAPIが更新されたら自動で呼び出される
+    //Handheldで変更されたシーンの情報を受け取る
+    public void onDataChanged(DataEventBuffer dataEvents) {//dataAPIが更新されたら自動で呼び出される
 
-        if (scene.equals("scene:Onemore")) {
-            Intent intent = new Intent(this, WearOnemoreActivity.class);//WearOnemoreActivityへ遷移
-            startActivity(intent);
+
+        for (DataEvent event : dataEvents) {
+            if (event.getType() == DataEvent.TYPE_DELETED) {
+                Log.d("TAG", "DataItem deleted: " + event.getDataItem().getUri());
+            } else if (event.getType() == DataEvent.TYPE_CHANGED) {
+                Log.d("TAG", "DataItem changed: " + event.getDataItem().getUri());
+                DataMap dataMap = DataMap.fromByteArray(event.getDataItem().getData());
+                //variable = dataMap.get~("keyname"); で受け取る
+                scene = dataMap.getString("scenename");
+
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        //受け取り後の処理をここに
+                        //resultview.setText(resultstr);
+
+                        if (scene.equals("scene:Onemore")) {
+                            Intent intent = new Intent(MainActivity.this,WearOnemoreActivity.class);//WearOnemoreActivityへ遷移
+                            startActivity(intent);
+                        }
+                    }
+                });
+            }
         }
+    }
+
+    public void SyncScene(String scenedata,String datapath){//HandheldとWear間のシーンの更新をする
+        PutDataMapRequest dataMapRequest = PutDataMapRequest.create(datapath);
+        DataMap dataMap = dataMapRequest.getDataMap();
+        //Data set
+        dataMap.putString("scenename", scenedata);//("keyname",data);
+
+        // Data Push
+        PutDataRequest request = dataMapRequest.asPutDataRequest();
+        PendingResult<DataApi.DataItemResult> pendingResult = Wearable.DataApi.putDataItem(globalv.mGoogleApiClient, request);
+        pendingResult.setResultCallback(new ResultCallback<DataApi.DataItemResult>() {
+            @Override
+            public void onResult(DataApi.DataItemResult dataItemResult) {
+                Log.d("TAG", "onResult:" + dataItemResult.getStatus().toString());
+            }
+        });
+
     }
 
     @Override

--- a/wear/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
+++ b/wear/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
@@ -151,7 +151,7 @@ public class MainActivity extends WearableActivity implements View.OnClickListen
                 Log.d("TAG", "DataItem changed: " + event.getDataItem().getUri());
                 DataMap dataMap = DataMap.fromByteArray(event.getDataItem().getData());
                 //variable = dataMap.get~("keyname"); で受け取る
-                scene = dataMap.getString("scenename");
+                scene = dataMap.getString("scene_name");
 
                 runOnUiThread(new Runnable() {
                     @Override
@@ -173,7 +173,7 @@ public class MainActivity extends WearableActivity implements View.OnClickListen
         PutDataMapRequest dataMapRequest = PutDataMapRequest.create(datapath);
         DataMap dataMap = dataMapRequest.getDataMap();
         //Data set
-        dataMap.putString("scenename", scenedata);//("keyname",data);
+        dataMap.putString("scene_name", scenedata);//("keyname",data);
 
         // Data Push
         PutDataRequest request = dataMapRequest.asPutDataRequest();

--- a/wear/src/main/java/jagsc/org/abc2016springclient/WearResultActivity.java
+++ b/wear/src/main/java/jagsc/org/abc2016springclient/WearResultActivity.java
@@ -3,33 +3,18 @@ package jagsc.org.abc2016springclient;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.wearable.activity.WearableActivity;
-import android.support.wearable.view.WearableDialogActivity;
-import android.util.Log;
 import android.view.View;
 import android.content.Intent;
 import android.widget.Button;
-import android.widget.EditText;
-
-import java.io.UnsupportedEncodingException;
 import java.lang.*;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.common.api.PendingResult;
-import com.google.android.gms.common.api.ResultCallback;
-import com.google.android.gms.common.api.Status;
-import com.google.android.gms.wearable.Asset;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataEventBuffer;
 import com.google.android.gms.wearable.DataItem;
 import com.google.android.gms.wearable.DataItemBuffer;
 import com.google.android.gms.wearable.DataMap;
-import com.google.android.gms.wearable.MessageApi;
-import com.google.android.gms.wearable.MessageEvent;
-import com.google.android.gms.wearable.Node;
-import com.google.android.gms.wearable.NodeApi;
-import com.google.android.gms.wearable.PutDataMapRequest;
-import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
 /**


### PR DESCRIPTION
Bluetoothまわりをcommunicationのコードを元に移植しました。
移植の際に以下の変更を加えました。

・新月に指摘された送受信が詰まるバグを解消
・ハンドヘルドでサーバーから受信時に":"で区切った前半を見てデータの種類を判断。データの種類ごとのkeynameでDataApiを用いてwearへ転送
(データの種類はCommunicationレポジトリの[issu#5DataAPIで用意するデータマップ](https://github.com/JAG-SC/ABC2016SpringCommunication/issues/5)を参照)
・クラス名をBluetoothTaskからBluetoothClientへ変更

DataApiについては以下の変更を加えました。

・前項で示した通り、データの種類ごとにwearへ転送するようにした。
※keynameごとの具体的な動作は未実装です。
