### PR TITLE
Handheldがサーバーと接続時に異常終了する問題を修正

### DIFF
--- a/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/BluetoothClient.java
@@ -35,8 +35,8 @@ public class BluetoothClient {
     private InputStream btIn;
     private OutputStream btOut;
 
-    private boolean is_inited=false;
-    private boolean is_connected=false;
+    private boolean have_connected=false; //過去に接続したことがあるかどうか
+    private boolean is_connected=false; //現在の接続状況
 
 
     private GlobalVariables globalv;
@@ -62,11 +62,10 @@ public class BluetoothClient {
             activity.errorDialog("This device is disabled Bluetooth.");
             return;
         }
-        is_inited=true;
     }
 
-    public boolean is_inited(){
-        return is_inited;
+    public boolean have_connected(){
+        return have_connected;
     }
 
     public boolean is_connected(){
@@ -154,6 +153,7 @@ public class BluetoothClient {
                 activity.errorDialog(result.toString());
             } else {
                 activity.hideWaitDialog();
+                have_connected=true;
             }
         }
     }

--- a/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
+++ b/mobile/src/main/java/jagsc/org/abc2016springclient/MainActivity.java
@@ -58,7 +58,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-
+        resultview = (TextView) findViewById(R.id.resulttxtview);
 
         globalv=(GlobalVariables) this.getApplication();
         mGoogleApiClient = new GoogleApiClient.Builder(this).addConnectionCallbacks(this).addApi(Wearable.API).build();
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
         super.onResume();
 
         mGoogleApiClient.connect();
-        if(bluetoothClient.is_inited()){
+        if(bluetoothClient.have_connected()){
             bluetoothClient.doConnect(null);
         }else{
             // Bluetooth初期化

--- a/mobile/src/main/res/layout/content_main.xml
+++ b/mobile/src/main/res/layout/content_main.xml
@@ -15,6 +15,7 @@
 
     <TextView
         android:text="Hello World!"
+        android:id="@+id/resulttxtview"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 </RelativeLayout>


### PR DESCRIPTION
以下に示す2種類の異常終了する不具合を修正しました。
#### ハンドヘルドがサーバーへの初回接続時に必ず異常終了する不具合

**原因:**Bluetoothまわりの移植の際に接続状態を表示するTextView(id:resulttxtview)のビューオブジェクトの取得し忘れ
**解決策:**該当レイアウトでidを設定した。
また、ハンドヘルドのMainActivityのonCreate内にfindViewByIdで該当ビューオブジェクトの取得をするようにした。
#### ハンドヘルドの接続先を選択する画面で他のアプリへ切り替えた後、選択画面へ再度遷移した際に異常終了する不具合

**原因:**BluetoothClientにて再接続の際に使用するデバイスの情報が取得済みであることを表すメソッドの更新タイミングが不適切であった。具体的には修正前はBluetoothの初期化後にデバイス情報を取得できたと判定していたが、実際にはその後にデバイス選択ダイアログを表示させ、ユーザーの選択を待つような処理であったため上記の問題が発生することとなった。
**解決策:**デバッグの結果、上記の原因が判明したため、初回の接続が確立してからデバイス情報を取得できたと判定するようにした。
